### PR TITLE
Reuse the action ref specified by the caller for nested actions

### DIFF
--- a/bash/action.yml
+++ b/bash/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Symlink current Actions repo
       working-directory: ${{ github.action_path }}
       shell: bash
-      run: ln -fs $(realpath ../)  /home/runner/work/_actions/current
+      run: ln -fs ../  /home/runner/work/_actions/current
 
     - name: Setup Runner
       uses: ./../../_actions/current/internal/setup-runner

--- a/bash/action.yml
+++ b/bash/action.yml
@@ -27,10 +27,10 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Runner
-      uses: protocolbuffers/protobuf-ci/internal/setup-runner@v1
+      uses: protocolbuffers/protobuf-ci/internal/setup-runner@${{github.action_ref}}
 
     - name: Update stale files using Bazel
-      uses: protocolbuffers/protobuf-ci/bazel@v1
+      uses: protocolbuffers/protobuf-ci/bazel@${{github.action_ref}}
       with:
         credentials: ${{ inputs.credentials }}
         bazel-cache: regenerate-stale-files

--- a/bash/action.yml
+++ b/bash/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - name: Symlink current Actions repo
       env:
-        GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
+        GH_ACTION_DIR: ${{ github.workspace }}/../../_actions/${{ github.action_repository }}/${{ github.action_ref }}/
         GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
       shell: bash
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE

--- a/bash/action.yml
+++ b/bash/action.yml
@@ -26,11 +26,16 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Symlink current Actions repo
+      working-directory: ${{ github.action_path }}
+      shell: bash
+      run: ln -fs $(realpath ../)  /home/runner/work/_actions/current
+
     - name: Setup Runner
-      uses: protocolbuffers/protobuf-ci/internal/setup-runner@${{github.action_ref}}
+      uses: ./../../_actions/current/internal/setup-runner
 
     - name: Update stale files using Bazel
-      uses: protocolbuffers/protobuf-ci/bazel@${{github.action_ref}}
+      uses: ./../../_actions/current/bazel
       with:
         credentials: ${{ inputs.credentials }}
         bazel-cache: regenerate-stale-files

--- a/bash/action.yml
+++ b/bash/action.yml
@@ -27,9 +27,8 @@ runs:
   using: 'composite'
   steps:
     - name: Symlink current Actions repo
-      working-directory: ${{ github.action_path }}
       shell: bash
-      run: ln -fs ../  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/  /home/runner/work/_actions/current
 
     - name: Setup Runner
       uses: ./../../_actions/current/internal/setup-runner

--- a/bash/action.yml
+++ b/bash/action.yml
@@ -28,10 +28,9 @@ runs:
   steps:
     - name: Symlink current Actions repo
       env:
-        GH_ACTION_REPO: ${{ github.action_repository }}
-        GH_ACTION_REF: ${{ github.action_ref }}
+        GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
       shell: bash
-      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_current_action
+      run: ln -fs $GH_ACTION_DIR $GITHUB_WORKSPACE/../../_current_action
 
     - name: Setup Runner
       uses: ././../../_current_action/internal/setup-runner

--- a/bash/action.yml
+++ b/bash/action.yml
@@ -29,15 +29,15 @@ runs:
     - name: Symlink current Actions repo
       env:
         GH_ACTION_DIR: ${{ github.workspace }}/../../_actions/${{ github.action_repository }}/${{ github.action_ref }}/
-        GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
+        GH_ACTION_CLONE: ${{ github.workspace }}/../../_actions/current
       shell: bash
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
     - name: Setup Runner
-      uses: ./../../_current_action/internal/setup-runner
+      uses: ./../../_actions/current/internal/setup-runner
 
     - name: Update stale files using Bazel
-      uses: ./../../_current_action/bazel
+      uses: ./../../_actions/current/bazel
       with:
         credentials: ${{ inputs.credentials }}
         bazel-cache: regenerate-stale-files

--- a/bash/action.yml
+++ b/bash/action.yml
@@ -29,8 +29,9 @@ runs:
     - name: Symlink current Actions repo
       env:
         GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
+        GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
       shell: bash
-      run: ln -fs $GH_ACTION_DIR $GITHUB_WORKSPACE/../../_current_action
+      run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
     - name: Setup Runner
       uses: ././../../_current_action/internal/setup-runner

--- a/bash/action.yml
+++ b/bash/action.yml
@@ -27,8 +27,11 @@ runs:
   using: 'composite'
   steps:
     - name: Symlink current Actions repo
+      env:
+        GH_ACTION_REPO: ${{ github.action_repository }}
+        GH_ACTION_REF: ${{ github.action_ref }}
       shell: bash
-      run: ln -fs /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_actions/current
 
     - name: Setup Runner
       uses: ./../../_actions/current/internal/setup-runner

--- a/bash/action.yml
+++ b/bash/action.yml
@@ -34,10 +34,10 @@ runs:
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
     - name: Setup Runner
-      uses: ././../../_current_action/internal/setup-runner
+      uses: ./../../_current_action/internal/setup-runner
 
     - name: Update stale files using Bazel
-      uses: ././../../_current_action/bazel
+      uses: ./../../_current_action/bazel
       with:
         credentials: ${{ inputs.credentials }}
         bazel-cache: regenerate-stale-files

--- a/bash/action.yml
+++ b/bash/action.yml
@@ -31,13 +31,13 @@ runs:
         GH_ACTION_REPO: ${{ github.action_repository }}
         GH_ACTION_REF: ${{ github.action_ref }}
       shell: bash
-      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_current_action
 
     - name: Setup Runner
-      uses: ./../../_actions/current/internal/setup-runner
+      uses: ././../../_current_action/internal/setup-runner
 
     - name: Update stale files using Bazel
-      uses: ./../../_actions/current/bazel
+      uses: ././../../_current_action/bazel
       with:
         credentials: ${{ inputs.credentials }}
         bazel-cache: regenerate-stale-files

--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -44,9 +44,8 @@ runs:
   using: 'composite'
   steps:
     - name: Symlink current Actions repo
-      working-directory: ${{ github.action_path }}
       shell: bash
-      run: ln -fs ../  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/  /home/runner/work/_actions/current
 
     - name: Authenticate
       id: auth

--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -45,16 +45,16 @@ runs:
   steps:
     - name: Authenticate
       id: auth
-      uses: protocolbuffers/protobuf-ci/internal/gcloud-auth@v1
+      uses: protocolbuffers/protobuf-ci/internal/gcloud-auth@${{github.action_ref}}
       with:
         credentials: ${{ inputs.credentials }}
 
     - name: Setup Runner
-      uses: protocolbuffers/protobuf-ci/internal/setup-runner@v1
+      uses: protocolbuffers/protobuf-ci/internal/setup-runner@${{github.action_ref}}
 
     - name: Setup Bazel
       id: bazel
-      uses: protocolbuffers/protobuf-ci/internal/bazel-setup@v1
+      uses: protocolbuffers/protobuf-ci/internal/bazel-setup@${{github.action_ref}}
       with:
         credentials-file: /workspace/$(basename ${{ steps.auth.outputs.credentials-file }})
         bazel-cache: ${{ inputs.bazel-cache }}
@@ -69,7 +69,7 @@ runs:
       run: echo "Invalid specification of both non-Bazel and Bazel command"; exit 1
 
     - name: Run Bash Docker
-      uses: protocolbuffers/protobuf-ci/internal/docker-run@v1
+      uses: protocolbuffers/protobuf-ci/internal/docker-run@${{github.action_ref}}
       if: ${{ inputs.bash }}
       with:
         image: ${{ inputs.image }}
@@ -77,7 +77,7 @@ runs:
         command: -l -c "${{ inputs.bash }}"
 
     - name: Run Bazel Docker
-      uses: protocolbuffers/protobuf-ci/internal/docker-run@v1
+      uses: protocolbuffers/protobuf-ci/internal/docker-run@${{github.action_ref}}
       if: ${{ !inputs.bash }}
       with:
         image: ${{ inputs.image }}
@@ -86,4 +86,4 @@ runs:
     - name: Save Bazel repository cache
       # Only allow repository cache updates during post-submits.
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
-      uses: protocolbuffers/protobuf-ci/internal/repository-cache-save@v1
+      uses: protocolbuffers/protobuf-ci/internal/repository-cache-save@${{github.action_ref}}

--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -43,18 +43,23 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Symlink current Actions repo
+      working-directory: ${{ github.action_path }}
+      shell: bash
+      run: ln -fs $(realpath ../)  /home/runner/work/_actions/current
+
     - name: Authenticate
       id: auth
-      uses: protocolbuffers/protobuf-ci/internal/gcloud-auth@${{github.action_ref}}
+      uses: ./../../_actions/current/internal/gcloud-auth
       with:
         credentials: ${{ inputs.credentials }}
 
     - name: Setup Runner
-      uses: protocolbuffers/protobuf-ci/internal/setup-runner@${{github.action_ref}}
+      uses: ./../../_actions/current/internal/setup-runner
 
     - name: Setup Bazel
       id: bazel
-      uses: protocolbuffers/protobuf-ci/internal/bazel-setup@${{github.action_ref}}
+      uses: ./../../_actions/current/internal/bazel-setup
       with:
         credentials-file: /workspace/$(basename ${{ steps.auth.outputs.credentials-file }})
         bazel-cache: ${{ inputs.bazel-cache }}
@@ -69,7 +74,7 @@ runs:
       run: echo "Invalid specification of both non-Bazel and Bazel command"; exit 1
 
     - name: Run Bash Docker
-      uses: protocolbuffers/protobuf-ci/internal/docker-run@${{github.action_ref}}
+      uses: ./../../_actions/current/internal/docker-run
       if: ${{ inputs.bash }}
       with:
         image: ${{ inputs.image }}
@@ -77,7 +82,7 @@ runs:
         command: -l -c "${{ inputs.bash }}"
 
     - name: Run Bazel Docker
-      uses: protocolbuffers/protobuf-ci/internal/docker-run@${{github.action_ref}}
+      uses: ./../../_actions/current/internal/docker-run
       if: ${{ !inputs.bash }}
       with:
         image: ${{ inputs.image }}
@@ -86,4 +91,4 @@ runs:
     - name: Save Bazel repository cache
       # Only allow repository cache updates during post-submits.
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
-      uses: protocolbuffers/protobuf-ci/internal/repository-cache-save@${{github.action_ref}}
+      uses: ./../../_actions/current/internal/repository-cache-save

--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -48,20 +48,20 @@ runs:
         GH_ACTION_REPO: ${{ github.action_repository }}
         GH_ACTION_REF: ${{ github.action_ref }}
       shell: bash
-      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_current_action
 
     - name: Authenticate
       id: auth
-      uses: ./../../_actions/current/internal/gcloud-auth
+      uses: ././../../_current_action/internal/gcloud-auth
       with:
         credentials: ${{ inputs.credentials }}
 
     - name: Setup Runner
-      uses: ./../../_actions/current/internal/setup-runner
+      uses: ././../../_current_action/internal/setup-runner
 
     - name: Setup Bazel
       id: bazel
-      uses: ./../../_actions/current/internal/bazel-setup
+      uses: ././../../_current_action/internal/bazel-setup
       with:
         credentials-file: /workspace/$(basename ${{ steps.auth.outputs.credentials-file }})
         bazel-cache: ${{ inputs.bazel-cache }}
@@ -76,7 +76,7 @@ runs:
       run: echo "Invalid specification of both non-Bazel and Bazel command"; exit 1
 
     - name: Run Bash Docker
-      uses: ./../../_actions/current/internal/docker-run
+      uses: ././../../_current_action/internal/docker-run
       if: ${{ inputs.bash }}
       with:
         image: ${{ inputs.image }}
@@ -84,7 +84,7 @@ runs:
         command: -l -c "${{ inputs.bash }}"
 
     - name: Run Bazel Docker
-      uses: ./../../_actions/current/internal/docker-run
+      uses: ././../../_current_action/internal/docker-run
       if: ${{ !inputs.bash }}
       with:
         image: ${{ inputs.image }}
@@ -93,4 +93,4 @@ runs:
     - name: Save Bazel repository cache
       # Only allow repository cache updates during post-submits.
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
-      uses: ./../../_actions/current/internal/repository-cache-save
+      uses: ././../../_current_action/internal/repository-cache-save

--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -44,8 +44,11 @@ runs:
   using: 'composite'
   steps:
     - name: Symlink current Actions repo
+      env:
+        GH_ACTION_REPO: ${{ github.action_repository }}
+        GH_ACTION_REF: ${{ github.action_ref }}
       shell: bash
-      run: ln -fs /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_actions/current
 
     - name: Authenticate
       id: auth

--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -45,10 +45,9 @@ runs:
   steps:
     - name: Symlink current Actions repo
       env:
-        GH_ACTION_REPO: ${{ github.action_repository }}
-        GH_ACTION_REF: ${{ github.action_ref }}
+        GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
       shell: bash
-      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_current_action
+      run: ln -fs $GH_ACTION_DIR $GITHUB_WORKSPACE/../../_current_action
 
     - name: Authenticate
       id: auth

--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -52,16 +52,16 @@ runs:
 
     - name: Authenticate
       id: auth
-      uses: ././../../_current_action/internal/gcloud-auth
+      uses: ./../../_current_action/internal/gcloud-auth
       with:
         credentials: ${{ inputs.credentials }}
 
     - name: Setup Runner
-      uses: ././../../_current_action/internal/setup-runner
+      uses: ./../../_current_action/internal/setup-runner
 
     - name: Setup Bazel
       id: bazel
-      uses: ././../../_current_action/internal/bazel-setup
+      uses: ./../../_current_action/internal/bazel-setup
       with:
         credentials-file: /workspace/$(basename ${{ steps.auth.outputs.credentials-file }})
         bazel-cache: ${{ inputs.bazel-cache }}
@@ -76,7 +76,7 @@ runs:
       run: echo "Invalid specification of both non-Bazel and Bazel command"; exit 1
 
     - name: Run Bash Docker
-      uses: ././../../_current_action/internal/docker-run
+      uses: ./../../_current_action/internal/docker-run
       if: ${{ inputs.bash }}
       with:
         image: ${{ inputs.image }}
@@ -84,7 +84,7 @@ runs:
         command: -l -c "${{ inputs.bash }}"
 
     - name: Run Bazel Docker
-      uses: ././../../_current_action/internal/docker-run
+      uses: ./../../_current_action/internal/docker-run
       if: ${{ !inputs.bash }}
       with:
         image: ${{ inputs.image }}
@@ -93,4 +93,4 @@ runs:
     - name: Save Bazel repository cache
       # Only allow repository cache updates during post-submits.
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
-      uses: ././../../_current_action/internal/repository-cache-save
+      uses: ./../../_current_action/internal/repository-cache-save

--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -45,7 +45,7 @@ runs:
   steps:
     - name: Symlink current Actions repo
       env:
-        GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
+        GH_ACTION_DIR: ${{ github.workspace }}/../../_actions/${{ github.action_repository }}/${{ github.action_ref }}/
         GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
       shell: bash
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE

--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -46,8 +46,9 @@ runs:
     - name: Symlink current Actions repo
       env:
         GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
+        GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
       shell: bash
-      run: ln -fs $GH_ACTION_DIR $GITHUB_WORKSPACE/../../_current_action
+      run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
     - name: Authenticate
       id: auth

--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -46,7 +46,7 @@ runs:
     - name: Symlink current Actions repo
       working-directory: ${{ github.action_path }}
       shell: bash
-      run: ln -fs $(realpath ../)  /home/runner/work/_actions/current
+      run: ln -fs ../  /home/runner/work/_actions/current
 
     - name: Authenticate
       id: auth

--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -46,22 +46,22 @@ runs:
     - name: Symlink current Actions repo
       env:
         GH_ACTION_DIR: ${{ github.workspace }}/../../_actions/${{ github.action_repository }}/${{ github.action_ref }}/
-        GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
+        GH_ACTION_CLONE: ${{ github.workspace }}/../../_actions/current
       shell: bash
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
     - name: Authenticate
       id: auth
-      uses: ./../../_current_action/internal/gcloud-auth
+      uses: ./../../_actions/current/internal/gcloud-auth
       with:
         credentials: ${{ inputs.credentials }}
 
     - name: Setup Runner
-      uses: ./../../_current_action/internal/setup-runner
+      uses: ./../../_actions/current/internal/setup-runner
 
     - name: Setup Bazel
       id: bazel
-      uses: ./../../_current_action/internal/bazel-setup
+      uses: ./../../_actions/current/internal/bazel-setup
       with:
         credentials-file: /workspace/$(basename ${{ steps.auth.outputs.credentials-file }})
         bazel-cache: ${{ inputs.bazel-cache }}
@@ -76,7 +76,7 @@ runs:
       run: echo "Invalid specification of both non-Bazel and Bazel command"; exit 1
 
     - name: Run Bash Docker
-      uses: ./../../_current_action/internal/docker-run
+      uses: ./../../_actions/current/internal/docker-run
       if: ${{ inputs.bash }}
       with:
         image: ${{ inputs.image }}
@@ -84,7 +84,7 @@ runs:
         command: -l -c "${{ inputs.bash }}"
 
     - name: Run Bazel Docker
-      uses: ./../../_current_action/internal/docker-run
+      uses: ./../../_actions/current/internal/docker-run
       if: ${{ !inputs.bash }}
       with:
         image: ${{ inputs.image }}
@@ -93,4 +93,4 @@ runs:
     - name: Save Bazel repository cache
       # Only allow repository cache updates during post-submits.
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
-      uses: ./../../_current_action/internal/repository-cache-save
+      uses: ./../../_actions/current/internal/repository-cache-save

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -47,10 +47,9 @@ runs:
   steps:
     - name: Symlink current Actions repo
       env:
-        GH_ACTION_REPO: ${{ github.action_repository }}
-        GH_ACTION_REF: ${{ github.action_ref }}
+        GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
       shell: bash
-      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_current_action
+      run: ln -fs $GH_ACTION_DIR $GITHUB_WORKSPACE/../../_current_action
 
     - name: Authenticate
       id: auth

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -48,22 +48,22 @@ runs:
     - name: Symlink current Actions repo
       env:
         GH_ACTION_DIR: ${{ github.workspace }}/../../_actions/${{ github.action_repository }}/${{ github.action_ref }}/
-        GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
+        GH_ACTION_CLONE: ${{ github.workspace }}/../../_actions/current
       shell: bash
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
     - name: Authenticate
       id: auth
-      uses: ./../../_current_action/internal/gcloud-auth
+      uses: ./../../_actions/current/internal/gcloud-auth
       with:
         credentials: ${{ inputs.credentials }}
 
     - name: Setup Runner
-      uses: ./../../_current_action/internal/setup-runner
+      uses: ./../../_actions/current/internal/setup-runner
 
     - name: Setup Bazel
       id: bazel
-      uses: ./../../_current_action/internal/bazel-setup
+      uses: ./../../_actions/current/internal/bazel-setup
       with:
         credentials-file: ${{ steps.auth.outputs.credentials-file }}
         bazel-cache: ${{ inputs.bazel-cache }}
@@ -152,4 +152,4 @@ runs:
     - name: Save Bazel repository cache
       # Only allow repository cache updates during post-submits.
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target'}}
-      uses: ./../../_current_action/internal/repository-cache-save
+      uses: ./../../_actions/current/internal/repository-cache-save

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -54,16 +54,16 @@ runs:
 
     - name: Authenticate
       id: auth
-      uses: ././../../_current_action/internal/gcloud-auth
+      uses: ./../../_current_action/internal/gcloud-auth
       with:
         credentials: ${{ inputs.credentials }}
 
     - name: Setup Runner
-      uses: ././../../_current_action/internal/setup-runner
+      uses: ./../../_current_action/internal/setup-runner
 
     - name: Setup Bazel
       id: bazel
-      uses: ././../../_current_action/internal/bazel-setup
+      uses: ./../../_current_action/internal/bazel-setup
       with:
         credentials-file: ${{ steps.auth.outputs.credentials-file }}
         bazel-cache: ${{ inputs.bazel-cache }}
@@ -152,4 +152,4 @@ runs:
     - name: Save Bazel repository cache
       # Only allow repository cache updates during post-submits.
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target'}}
-      uses: ././../../_current_action/internal/repository-cache-save
+      uses: ./../../_current_action/internal/repository-cache-save

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -47,16 +47,16 @@ runs:
   steps:
     - name: Authenticate
       id: auth
-      uses: protocolbuffers/protobuf-ci/internal/gcloud-auth@v1
+      uses: protocolbuffers/protobuf-ci/internal/gcloud-auth@${{github.action_ref}}
       with:
         credentials: ${{ inputs.credentials }}
 
     - name: Setup Runner
-      uses: protocolbuffers/protobuf-ci/internal/setup-runner@v1
+      uses: protocolbuffers/protobuf-ci/internal/setup-runner@${{github.action_ref}}
 
     - name: Setup Bazel
       id: bazel
-      uses: protocolbuffers/protobuf-ci/internal/bazel-setup@v1
+      uses: protocolbuffers/protobuf-ci/internal/bazel-setup@${{github.action_ref}}
       with:
         credentials-file: ${{ steps.auth.outputs.credentials-file }}
         bazel-cache: ${{ inputs.bazel-cache }}
@@ -145,4 +145,4 @@ runs:
     - name: Save Bazel repository cache
       # Only allow repository cache updates during post-submits.
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target'}}
-      uses: protocolbuffers/protobuf-ci/internal/repository-cache-save@v1
+      uses: protocolbuffers/protobuf-ci/internal/repository-cache-save@${{github.action_ref}}

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -45,18 +45,23 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Symlink current Actions repo
+      working-directory: ${{ github.action_path }}
+      shell: bash
+      run: ln -fs $(realpath ../)  /home/runner/work/_actions/current
+
     - name: Authenticate
       id: auth
-      uses: protocolbuffers/protobuf-ci/internal/gcloud-auth@${{github.action_ref}}
+      uses: ./../../_actions/current/internal/gcloud-auth
       with:
         credentials: ${{ inputs.credentials }}
 
     - name: Setup Runner
-      uses: protocolbuffers/protobuf-ci/internal/setup-runner@${{github.action_ref}}
+      uses: ./../../_actions/current/internal/setup-runner
 
     - name: Setup Bazel
       id: bazel
-      uses: protocolbuffers/protobuf-ci/internal/bazel-setup@${{github.action_ref}}
+      uses: ./../../_actions/current/internal/bazel-setup
       with:
         credentials-file: ${{ steps.auth.outputs.credentials-file }}
         bazel-cache: ${{ inputs.bazel-cache }}
@@ -145,4 +150,4 @@ runs:
     - name: Save Bazel repository cache
       # Only allow repository cache updates during post-submits.
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target'}}
-      uses: protocolbuffers/protobuf-ci/internal/repository-cache-save@${{github.action_ref}}
+      uses: ./../../_actions/current/internal/repository-cache-save

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -50,20 +50,20 @@ runs:
         GH_ACTION_REPO: ${{ github.action_repository }}
         GH_ACTION_REF: ${{ github.action_ref }}
       shell: bash
-      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_current_action
 
     - name: Authenticate
       id: auth
-      uses: ./../../_actions/current/internal/gcloud-auth
+      uses: ././../../_current_action/internal/gcloud-auth
       with:
         credentials: ${{ inputs.credentials }}
 
     - name: Setup Runner
-      uses: ./../../_actions/current/internal/setup-runner
+      uses: ././../../_current_action/internal/setup-runner
 
     - name: Setup Bazel
       id: bazel
-      uses: ./../../_actions/current/internal/bazel-setup
+      uses: ././../../_current_action/internal/bazel-setup
       with:
         credentials-file: ${{ steps.auth.outputs.credentials-file }}
         bazel-cache: ${{ inputs.bazel-cache }}
@@ -152,4 +152,4 @@ runs:
     - name: Save Bazel repository cache
       # Only allow repository cache updates during post-submits.
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target'}}
-      uses: ./../../_actions/current/internal/repository-cache-save
+      uses: ././../../_current_action/internal/repository-cache-save

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -48,7 +48,7 @@ runs:
     - name: Symlink current Actions repo
       working-directory: ${{ github.action_path }}
       shell: bash
-      run: ln -fs $(realpath ../)  /home/runner/work/_actions/current
+      run: ln -fs ../  /home/runner/work/_actions/current
 
     - name: Authenticate
       id: auth

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -48,8 +48,9 @@ runs:
     - name: Symlink current Actions repo
       env:
         GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
+        GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
       shell: bash
-      run: ln -fs $GH_ACTION_DIR $GITHUB_WORKSPACE/../../_current_action
+      run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
     - name: Authenticate
       id: auth

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -46,8 +46,11 @@ runs:
   using: 'composite'
   steps:
     - name: Symlink current Actions repo
+      env:
+        GH_ACTION_REPO: ${{ github.action_repository }}
+        GH_ACTION_REF: ${{ github.action_ref }}
       shell: bash
-      run: ln -fs /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_actions/current
 
     - name: Authenticate
       id: auth

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -46,9 +46,8 @@ runs:
   using: 'composite'
   steps:
     - name: Symlink current Actions repo
-      working-directory: ${{ github.action_path }}
       shell: bash
-      run: ln -fs ../  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/  /home/runner/work/_actions/current
 
     - name: Authenticate
       id: auth

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -47,7 +47,7 @@ runs:
   steps:
     - name: Symlink current Actions repo
       env:
-        GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
+        GH_ACTION_DIR: ${{ github.workspace }}/../../_actions/${{ github.action_repository }}/${{ github.action_ref }}/
         GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
       shell: bash
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - name: Symlink current Actions repo
       env:
-        GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
+        GH_ACTION_DIR: ${{ github.workspace }}/../../_actions/${{ github.action_repository }}/${{ github.action_ref }}/
         GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
       shell: bash
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -31,7 +31,7 @@ runs:
         GH_ACTION_REPO: ${{ github.action_repository }}
         GH_ACTION_REF: ${{ github.action_ref }}
       shell: bash
-      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_current_action
 
     - name: Configure ccache environment variables
       shell: bash
@@ -47,7 +47,7 @@ runs:
 
     - name: Setup ccache on Windows
       if: ${{ runner.os == 'Windows' }}
-      uses: ./../../_actions/current/internal/ccache-setup-windows
+      uses: ././../../_current_action/internal/ccache-setup-windows
     - name: Setup ccache on Mac
       if: ${{ runner.os == 'macOS' }}
       shell: bash

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Symlink current Actions repo
       working-directory: ${{ github.action_path }}
       shell: bash
-      run: ln -fs $(realpath ../)  /home/runner/work/_actions/current
+      run: ln -fs ../  /home/runner/work/_actions/current
 
     - name: Configure ccache environment variables
       shell: bash

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -29,8 +29,9 @@ runs:
     - name: Symlink current Actions repo
       env:
         GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
+        GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
       shell: bash
-      run: ln -fs $GH_ACTION_DIR $GITHUB_WORKSPACE/../../_current_action
+      run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
     - name: Configure ccache environment variables
       shell: bash

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Symlink current Actions repo
       env:
         GH_ACTION_DIR: ${{ github.workspace }}/../../_actions/${{ github.action_repository }}/${{ github.action_ref }}/
-        GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
+        GH_ACTION_CLONE: ${{ github.workspace }}/../../_actions/current
       shell: bash
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
@@ -47,7 +47,7 @@ runs:
 
     - name: Setup ccache on Windows
       if: ${{ runner.os == 'Windows' }}
-      uses: ./../../_current_action/internal/ccache-setup-windows
+      uses: ./../../_actions/current/internal/ccache-setup-windows
     - name: Setup ccache on Mac
       if: ${{ runner.os == 'macOS' }}
       shell: bash

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -40,7 +40,7 @@ runs:
 
     - name: Setup ccache on Windows
       if: ${{ runner.os == 'Windows' }}
-      uses: protocolbuffers/protobuf-ci/internal/ccache-setup-windows@v1
+      uses: protocolbuffers/protobuf-ci/internal/ccache-setup-windows@${{github.action_ref}}
     - name: Setup ccache on Mac
       if: ${{ runner.os == 'macOS' }}
       shell: bash

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -26,6 +26,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Symlink current Actions repo
+      working-directory: ${{ github.action_path }}
+      shell: bash
+      run: ln -fs $(realpath ../)  /home/runner/work/_actions/current
+
     - name: Configure ccache environment variables
       shell: bash
       run: |
@@ -40,7 +45,7 @@ runs:
 
     - name: Setup ccache on Windows
       if: ${{ runner.os == 'Windows' }}
-      uses: protocolbuffers/protobuf-ci/internal/ccache-setup-windows@${{github.action_ref}}
+      uses: ./../../_actions/current/internal/ccache-setup-windows
     - name: Setup ccache on Mac
       if: ${{ runner.os == 'macOS' }}
       shell: bash

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -27,8 +27,11 @@ runs:
   using: 'composite'
   steps:
     - name: Symlink current Actions repo
+      env:
+        GH_ACTION_REPO: ${{ github.action_repository }}
+        GH_ACTION_REF: ${{ github.action_ref }}
       shell: bash
-      run: ln -fs /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_actions/current
 
     - name: Configure ccache environment variables
       shell: bash

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -28,10 +28,9 @@ runs:
   steps:
     - name: Symlink current Actions repo
       env:
-        GH_ACTION_REPO: ${{ github.action_repository }}
-        GH_ACTION_REF: ${{ github.action_ref }}
+        GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
       shell: bash
-      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_current_action
+      run: ln -fs $GH_ACTION_DIR $GITHUB_WORKSPACE/../../_current_action
 
     - name: Configure ccache environment variables
       shell: bash

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -27,9 +27,8 @@ runs:
   using: 'composite'
   steps:
     - name: Symlink current Actions repo
-      working-directory: ${{ github.action_path }}
       shell: bash
-      run: ln -fs ../  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/  /home/runner/work/_actions/current
 
     - name: Configure ccache environment variables
       shell: bash

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -47,7 +47,7 @@ runs:
 
     - name: Setup ccache on Windows
       if: ${{ runner.os == 'Windows' }}
-      uses: ././../../_current_action/internal/ccache-setup-windows
+      uses: ./../../_current_action/internal/ccache-setup-windows
     - name: Setup ccache on Mac
       if: ${{ runner.os == 'macOS' }}
       shell: bash

--- a/cross-compile-protoc/action.yml
+++ b/cross-compile-protoc/action.yml
@@ -34,7 +34,7 @@ runs:
     - name: Symlink current Actions repo
       working-directory: ${{ github.action_path }}
       shell: bash
-      run: ln -fs $(realpath ../)  /home/runner/work/_actions/current
+      run: ln -fs ../  /home/runner/work/_actions/current
 
     - name: Cross compile protoc for ${{ inputs.architecture }}
       uses: ./../../_actions/current/bazel-docker

--- a/cross-compile-protoc/action.yml
+++ b/cross-compile-protoc/action.yml
@@ -33,10 +33,9 @@ runs:
   steps:
     - name: Symlink current Actions repo
       env:
-        GH_ACTION_REPO: ${{ github.action_repository }}
-        GH_ACTION_REF: ${{ github.action_ref }}
+        GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
       shell: bash
-      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_current_action
+      run: ln -fs $GH_ACTION_DIR $GITHUB_WORKSPACE/../../_current_action
 
     - name: Cross compile protoc for ${{ inputs.architecture }}
       uses: ././../../_current_action/bazel-docker

--- a/cross-compile-protoc/action.yml
+++ b/cross-compile-protoc/action.yml
@@ -32,7 +32,7 @@ runs:
   using: 'composite'
   steps:
     - name: Cross compile protoc for ${{ inputs.architecture }}
-      uses: protocolbuffers/protobuf-ci/bazel-docker@v1
+      uses: protocolbuffers/protobuf-ci/bazel-docker@${{github.action_ref}}
       with:
         credentials: ${{ inputs.credentials }}
         bazel-cache: xcompile-protoc/${{ inputs.architecture }}

--- a/cross-compile-protoc/action.yml
+++ b/cross-compile-protoc/action.yml
@@ -31,8 +31,13 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Symlink current Actions repo
+      working-directory: ${{ github.action_path }}
+      shell: bash
+      run: ln -fs $(realpath ../)  /home/runner/work/_actions/current
+
     - name: Cross compile protoc for ${{ inputs.architecture }}
-      uses: protocolbuffers/protobuf-ci/bazel-docker@${{github.action_ref}}
+      uses: ./../../_actions/current/bazel-docker
       with:
         credentials: ${{ inputs.credentials }}
         bazel-cache: xcompile-protoc/${{ inputs.architecture }}

--- a/cross-compile-protoc/action.yml
+++ b/cross-compile-protoc/action.yml
@@ -34,8 +34,9 @@ runs:
     - name: Symlink current Actions repo
       env:
         GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
+        GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
       shell: bash
-      run: ln -fs $GH_ACTION_DIR $GITHUB_WORKSPACE/../../_current_action
+      run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
     - name: Cross compile protoc for ${{ inputs.architecture }}
       uses: ././../../_current_action/bazel-docker

--- a/cross-compile-protoc/action.yml
+++ b/cross-compile-protoc/action.yml
@@ -32,8 +32,11 @@ runs:
   using: 'composite'
   steps:
     - name: Symlink current Actions repo
+      env:
+        GH_ACTION_REPO: ${{ github.action_repository }}
+        GH_ACTION_REF: ${{ github.action_ref }}
       shell: bash
-      run: ln -fs /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_actions/current
 
     - name: Cross compile protoc for ${{ inputs.architecture }}
       uses: ./../../_actions/current/bazel-docker

--- a/cross-compile-protoc/action.yml
+++ b/cross-compile-protoc/action.yml
@@ -34,12 +34,12 @@ runs:
     - name: Symlink current Actions repo
       env:
         GH_ACTION_DIR: ${{ github.workspace }}/../../_actions/${{ github.action_repository }}/${{ github.action_ref }}/
-        GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
+        GH_ACTION_CLONE: ${{ github.workspace }}/../../_actions/current
       shell: bash
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
     - name: Cross compile protoc for ${{ inputs.architecture }}
-      uses: ./../../_current_action/bazel-docker
+      uses: ./../../_actions/current/bazel-docker
       with:
         credentials: ${{ inputs.credentials }}
         bazel-cache: xcompile-protoc/${{ inputs.architecture }}

--- a/cross-compile-protoc/action.yml
+++ b/cross-compile-protoc/action.yml
@@ -39,7 +39,7 @@ runs:
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
     - name: Cross compile protoc for ${{ inputs.architecture }}
-      uses: ././../../_current_action/bazel-docker
+      uses: ./../../_current_action/bazel-docker
       with:
         credentials: ${{ inputs.credentials }}
         bazel-cache: xcompile-protoc/${{ inputs.architecture }}

--- a/cross-compile-protoc/action.yml
+++ b/cross-compile-protoc/action.yml
@@ -33,7 +33,7 @@ runs:
   steps:
     - name: Symlink current Actions repo
       env:
-        GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
+        GH_ACTION_DIR: ${{ github.workspace }}/../../_actions/${{ github.action_repository }}/${{ github.action_ref }}/
         GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
       shell: bash
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE

--- a/cross-compile-protoc/action.yml
+++ b/cross-compile-protoc/action.yml
@@ -36,10 +36,10 @@ runs:
         GH_ACTION_REPO: ${{ github.action_repository }}
         GH_ACTION_REF: ${{ github.action_ref }}
       shell: bash
-      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_current_action
 
     - name: Cross compile protoc for ${{ inputs.architecture }}
-      uses: ./../../_actions/current/bazel-docker
+      uses: ././../../_current_action/bazel-docker
       with:
         credentials: ${{ inputs.credentials }}
         bazel-cache: xcompile-protoc/${{ inputs.architecture }}

--- a/cross-compile-protoc/action.yml
+++ b/cross-compile-protoc/action.yml
@@ -32,9 +32,8 @@ runs:
   using: 'composite'
   steps:
     - name: Symlink current Actions repo
-      working-directory: ${{ github.action_path }}
       shell: bash
-      run: ln -fs ../  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/  /home/runner/work/_actions/current
 
     - name: Cross compile protoc for ${{ inputs.architecture }}
       uses: ./../../_actions/current/bazel-docker

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -40,11 +40,11 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Runner
-      uses: protocolbuffers/protobuf-ci/internal/setup-runner@v1
+      uses: protocolbuffers/protobuf-ci/internal/setup-runner@${{github.action_ref}}
 
     - name: Update stale files using Bazel
       if: ${{ !inputs.skip-staleness-check }}
-      uses: protocolbuffers/protobuf-ci/bazel-docker@v1
+      uses: protocolbuffers/protobuf-ci/bazel-docker@${{github.action_ref}}
       with:
         image: us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:5.1.1-aec4d74f2eb6938fc53ef7d9a79a4bf2da24abc1
         credentials: ${{ inputs.credentials }}
@@ -57,7 +57,7 @@ runs:
       run: echo "DOCKER_RUN_FLAGS=--platform ${{inputs.platform}}" >> $GITHUB_ENV
 
     - name: Run Docker
-      uses: protocolbuffers/protobuf-ci/internal/docker-run@v1
+      uses: protocolbuffers/protobuf-ci/internal/docker-run@${{github.action_ref}}
       with:
         image: ${{ inputs.image }}
         command: ${{ inputs.command }}

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -42,16 +42,16 @@ runs:
     - name: Symlink current Actions repo
       env:
         GH_ACTION_DIR: ${{ github.workspace }}/../../_actions/${{ github.action_repository }}/${{ github.action_ref }}/
-        GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
+        GH_ACTION_CLONE: ${{ github.workspace }}/../../_actions/current
       shell: bash
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
     - name: Setup Runner
-      uses: ./../../_current_action/internal/setup-runner
+      uses: ./../../_actions/current/internal/setup-runner
 
     - name: Update stale files using Bazel
       if: ${{ !inputs.skip-staleness-check }}
-      uses: ./../../_current_action/bazel-docker
+      uses: ./../../_actions/current/bazel-docker
       with:
         image: us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:5.1.1-aec4d74f2eb6938fc53ef7d9a79a4bf2da24abc1
         credentials: ${{ inputs.credentials }}
@@ -64,7 +64,7 @@ runs:
       run: echo "DOCKER_RUN_FLAGS=--platform ${{inputs.platform}}" >> $GITHUB_ENV
 
     - name: Run Docker
-      uses: ./../../_current_action/internal/docker-run
+      uses: ./../../_actions/current/internal/docker-run
       with:
         image: ${{ inputs.image }}
         command: ${{ inputs.command }}

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -41,10 +41,9 @@ runs:
   steps:
     - name: Symlink current Actions repo
       env:
-        GH_ACTION_REPO: ${{ github.action_repository }}
-        GH_ACTION_REF: ${{ github.action_ref }}
+        GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
       shell: bash
-      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_current_action
+      run: ln -fs $GH_ACTION_DIR $GITHUB_WORKSPACE/../../_current_action
 
     - name: Setup Runner
       uses: ././../../_current_action/internal/setup-runner

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -42,8 +42,9 @@ runs:
     - name: Symlink current Actions repo
       env:
         GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
+        GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
       shell: bash
-      run: ln -fs $GH_ACTION_DIR $GITHUB_WORKSPACE/../../_current_action
+      run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
     - name: Setup Runner
       uses: ././../../_current_action/internal/setup-runner

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -44,14 +44,14 @@ runs:
         GH_ACTION_REPO: ${{ github.action_repository }}
         GH_ACTION_REF: ${{ github.action_ref }}
       shell: bash
-      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_current_action
 
     - name: Setup Runner
-      uses: ./../../_actions/current/internal/setup-runner
+      uses: ././../../_current_action/internal/setup-runner
 
     - name: Update stale files using Bazel
       if: ${{ !inputs.skip-staleness-check }}
-      uses: ./../../_actions/current/bazel-docker
+      uses: ././../../_current_action/bazel-docker
       with:
         image: us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:5.1.1-aec4d74f2eb6938fc53ef7d9a79a4bf2da24abc1
         credentials: ${{ inputs.credentials }}
@@ -64,7 +64,7 @@ runs:
       run: echo "DOCKER_RUN_FLAGS=--platform ${{inputs.platform}}" >> $GITHUB_ENV
 
     - name: Run Docker
-      uses: ./../../_actions/current/internal/docker-run
+      uses: ././../../_current_action/internal/docker-run
       with:
         image: ${{ inputs.image }}
         command: ${{ inputs.command }}

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -39,12 +39,17 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Symlink current Actions repo
+      working-directory: ${{ github.action_path }}
+      shell: bash
+      run: ln -fs $(realpath ../)  /home/runner/work/_actions/current
+
     - name: Setup Runner
-      uses: protocolbuffers/protobuf-ci/internal/setup-runner@${{github.action_ref}}
+      uses: ./../../_actions/current/internal/setup-runner
 
     - name: Update stale files using Bazel
       if: ${{ !inputs.skip-staleness-check }}
-      uses: protocolbuffers/protobuf-ci/bazel-docker@${{github.action_ref}}
+      uses: ./../../_actions/current/bazel-docker
       with:
         image: us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:5.1.1-aec4d74f2eb6938fc53ef7d9a79a4bf2da24abc1
         credentials: ${{ inputs.credentials }}
@@ -57,7 +62,7 @@ runs:
       run: echo "DOCKER_RUN_FLAGS=--platform ${{inputs.platform}}" >> $GITHUB_ENV
 
     - name: Run Docker
-      uses: protocolbuffers/protobuf-ci/internal/docker-run@${{github.action_ref}}
+      uses: ./../../_actions/current/internal/docker-run
       with:
         image: ${{ inputs.image }}
         command: ${{ inputs.command }}

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Symlink current Actions repo
       working-directory: ${{ github.action_path }}
       shell: bash
-      run: ln -fs $(realpath ../)  /home/runner/work/_actions/current
+      run: ln -fs ../  /home/runner/work/_actions/current
 
     - name: Setup Runner
       uses: ./../../_actions/current/internal/setup-runner

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -47,11 +47,11 @@ runs:
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
     - name: Setup Runner
-      uses: ././../../_current_action/internal/setup-runner
+      uses: ./../../_current_action/internal/setup-runner
 
     - name: Update stale files using Bazel
       if: ${{ !inputs.skip-staleness-check }}
-      uses: ././../../_current_action/bazel-docker
+      uses: ./../../_current_action/bazel-docker
       with:
         image: us-docker.pkg.dev/protobuf-build/containers/common/linux/bazel:5.1.1-aec4d74f2eb6938fc53ef7d9a79a4bf2da24abc1
         credentials: ${{ inputs.credentials }}
@@ -64,7 +64,7 @@ runs:
       run: echo "DOCKER_RUN_FLAGS=--platform ${{inputs.platform}}" >> $GITHUB_ENV
 
     - name: Run Docker
-      uses: ././../../_current_action/internal/docker-run
+      uses: ./../../_current_action/internal/docker-run
       with:
         image: ${{ inputs.image }}
         command: ${{ inputs.command }}

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -40,9 +40,8 @@ runs:
   using: 'composite'
   steps:
     - name: Symlink current Actions repo
-      working-directory: ${{ github.action_path }}
       shell: bash
-      run: ln -fs ../  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/  /home/runner/work/_actions/current
 
     - name: Setup Runner
       uses: ./../../_actions/current/internal/setup-runner

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -40,8 +40,11 @@ runs:
   using: 'composite'
   steps:
     - name: Symlink current Actions repo
+      env:
+        GH_ACTION_REPO: ${{ github.action_repository }}
+        GH_ACTION_REF: ${{ github.action_ref }}
       shell: bash
-      run: ln -fs /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/  /home/runner/work/_actions/current
+      run: ln -fs /home/runner/work/_actions/$GH_ACTION_REPO/$GH_ACTION_REF/  /home/runner/work/_actions/current
 
     - name: Setup Runner
       uses: ./../../_actions/current/internal/setup-runner

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -41,7 +41,7 @@ runs:
   steps:
     - name: Symlink current Actions repo
       env:
-        GH_ACTION_DIR: /home/runner/work/_actions/${{ github.action_repository }}/${{ github.action_ref }}/
+        GH_ACTION_DIR: ${{ github.workspace }}/../../_actions/${{ github.action_repository }}/${{ github.action_ref }}/
         GH_ACTION_CLONE: ${{ github.workspace }}/../../_current_action
       shell: bash
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE

--- a/internal/bazel-setup/action.yml
+++ b/internal/bazel-setup/action.yml
@@ -84,6 +84,6 @@ runs:
         echo "bazel-startup-flags=$BAZEL_STARTUP_FLAGS" >> $GITHUB_OUTPUT
 
     - name: Restore Bazel repository cache
-      uses: ./../../_actions/current/internal/repository-cache-restore
+      uses: ./../../_current_action/internal/repository-cache-restore
       with:
         bazel-cache: ${{ inputs.bazel-cache }}

--- a/internal/bazel-setup/action.yml
+++ b/internal/bazel-setup/action.yml
@@ -84,6 +84,6 @@ runs:
         echo "bazel-startup-flags=$BAZEL_STARTUP_FLAGS" >> $GITHUB_OUTPUT
 
     - name: Restore Bazel repository cache
-      uses: ./../../_current_action/internal/repository-cache-restore
+      uses: ./../../_actions/current/internal/repository-cache-restore
       with:
         bazel-cache: ${{ inputs.bazel-cache }}

--- a/internal/bazel-setup/action.yml
+++ b/internal/bazel-setup/action.yml
@@ -84,6 +84,6 @@ runs:
         echo "bazel-startup-flags=$BAZEL_STARTUP_FLAGS" >> $GITHUB_OUTPUT
 
     - name: Restore Bazel repository cache
-      uses: protocolbuffers/protobuf-ci/internal/repository-cache-restore@${{github.action_ref}}
+      uses: ./../../_actions/current/internal/repository-cache-restore
       with:
         bazel-cache: ${{ inputs.bazel-cache }}

--- a/internal/bazel-setup/action.yml
+++ b/internal/bazel-setup/action.yml
@@ -84,6 +84,6 @@ runs:
         echo "bazel-startup-flags=$BAZEL_STARTUP_FLAGS" >> $GITHUB_OUTPUT
 
     - name: Restore Bazel repository cache
-      uses: protocolbuffers/protobuf-ci/internal/repository-cache-restore@v1
+      uses: protocolbuffers/protobuf-ci/internal/repository-cache-restore@${{github.action_ref}}
       with:
         bazel-cache: ${{ inputs.bazel-cache }}


### PR DESCRIPTION
This will allow us to more easily test version bumps, and also avoid version skew between actions.  This was qualified with https://github.com/protocolbuffers/protobuf/pull/12057 and a temporary tag `version-test`