### PR TITLE
Upgrade to ccache 4.8 and make version configurable

### DIFF
--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -27,6 +27,11 @@ inputs:
     default: '2019'
     description: The version of Visual Studio to use (Windows only)
     type: string
+  ccache-version:
+    required: false
+    default: '4.8'
+    description: A pinned version of ccache
+    type: string
 
 runs:
   using: 'composite'
@@ -54,6 +59,7 @@ runs:
       if: ${{ runner.os == 'Windows' }}
       uses: ./../../_actions/current/internal/ccache-setup-windows
       with:
+        ccache-version: ${{ inputs.ccache-version }}
         vsversion: ${{ inputs.vsversion }}
     - name: Setup ccache on Mac
       if: ${{ runner.os == 'macOS' }}

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -43,18 +43,6 @@ runs:
       shell: bash
       run: ln -fs $GH_ACTION_DIR $GH_ACTION_CLONE
 
-    - name: Configure ccache environment variables
-      shell: bash
-      run: |
-        echo "CCACHE_BASEDIR=${{ github.workspace }}" >> $GITHUB_ENV
-        echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
-        echo "CCACHE_COMPRESS=true" >> $GITHUB_ENV
-        echo "CCACHE_COMPRESSLEVEL=5" >> $GITHUB_ENV
-        echo "CCACHE_MAXSIZE=100M" >> $GITHUB_ENV
-        echo "CCACHE_SLOPPINESS=clang_index_store,include_file_ctime,include_file_mtime,file_macro,time_macros" >> $GITHUB_ENV
-        echo "CCACHE_DIRECT=true" >> $GITHUB_ENV
-        echo "CCACHE_CMAKE_FLAGS=-Dprotobuf_ALLOW_CCACHE=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-
     - name: Setup ccache on Windows
       if: ${{ runner.os == 'Windows' }}
       uses: ./../../_actions/current/internal/ccache-setup-windows
@@ -65,6 +53,18 @@ runs:
       if: ${{ runner.os == 'macOS' }}
       shell: bash
       run: brew install ccache
+
+    - name: Configure ccache environment variables
+      shell: bash
+      run: |
+        echo "CCACHE_BASEDIR=${{ github.workspace }}" >> $GITHUB_ENV
+        echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
+        echo "CCACHE_COMPRESS=true" >> $GITHUB_ENV
+        echo "CCACHE_COMPRESSLEVEL=5" >> $GITHUB_ENV
+        echo "CCACHE_MAXSIZE=100M" >> $GITHUB_ENV
+        echo "CCACHE_SLOPPINESS=clang_index_store,include_file_ctime,include_file_mtime,file_macro,time_macros" >> $GITHUB_ENV
+        echo "CCACHE_DIRECT=true" >> $GITHUB_ENV
+        echo "CCACHE_CMAKE_FLAGS=-Dprotobuf_ALLOW_CCACHE=ON -DCMAKE_C_COMPILER_LAUNCHER=$(which ccache) -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)" >> $GITHUB_ENV
 
     - name: Setup fixed path ccache caching
       uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # v3.2.4


### PR DESCRIPTION
This also fixes a pre-existing bug where github's default 4.3 version was being used by cmake/ninja (instead of the one we download and install).  This was notably causing very long build times on the windows 2022 build