### PR TITLE
Workaround flaky mac timeouts

### DIFF
--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -76,7 +76,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        echo "BAZEL_VERSION=${{ inputs.version || '6.2.0' }}" >> $GITHUB_ENV
+        echo "BAZEL_VERSION=${{ inputs.version || '6.1.0' }}" >> $GITHUB_ENV
         echo "BAZEL_OSX_EXECUTE_TIMEOUT=600" >> $GITHUB_ENV
 
     - name: Select default Bazel version

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -29,7 +29,7 @@ inputs:
   version:
     required: false
     description: A pinned Bazel version to use
-    default: '5.1.1'
+    default: ''
     type: string
   bazel:
     required: false
@@ -68,6 +68,22 @@ runs:
         credentials-file: ${{ steps.auth.outputs.credentials-file }}
         bazel-cache: ${{ inputs.bazel-cache }}
 
+    # Earlier versions of Bazel cause relatively high flake rates due to
+    # https://github.com/bazelbuild/bazel/issues/17437.  Default to 6.2.0 where
+    # the BAZEL_OSX_EXECUTE_TIMEOUT environment variable can override this
+    # timeout.
+    - name: Workaround mac timeouts
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        echo "BAZEL_VERSION=${{ inputs.version || '6.2.0' }}" >> $GITHUB_ENV
+        echo "BAZEL_OSX_EXECUTE_TIMEOUT=600" >> $GITHUB_ENV
+
+    - name: Select default Bazel version
+      if: runner.os != 'macOS'
+      shell: bash
+      run: echo "BAZEL_VERSION=${{ inputs.version || '5.1.1' }}" >> $GITHUB_ENV
+
     - name: Get Linux bazelisk path
       if: runner.os == 'Linux'
       shell: bash
@@ -88,14 +104,14 @@ runs:
       uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # v3.2.4
       with:
         path: ${{ env.BAZELISK_PATH }}
-        key: bazel-${{ runner.os }}-${{ inputs.version }}
+        key: bazel-${{ runner.os }}-${{ env.BAZEL_VERSION }}
 
     - name: Restore Bazelisk
       if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
       uses: actions/cache/restore@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # v3.2.4
       with:
         path: ${{ env.BAZELISK_PATH }}
-        key: bazel-${{ runner.os }}-${{ inputs.version }}
+        key: bazel-${{ runner.os }}-${{ env.BAZEL_VERSION}}
 
     - name: Hook up repository Cache
       shell: bash
@@ -108,7 +124,7 @@ runs:
 
     - name: Pin Bazel version
       shell: bash
-      run: echo "USE_BAZEL_VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+      run: echo "USE_BAZEL_VERSION=${{ env.BAZEL_VERSION }}" >> $GITHUB_ENV
 
     - name: Output Bazel version
       shell: bash

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -130,29 +130,6 @@ runs:
       shell: bash
       run: bazelisk version
 
-    # Bazel has multiple Xcode calls with hardcoded timeouts.  Many of these
-    # end up timing out on our github runners, causing flakes on every mac
-    # build that invoked Bazel.  To work around this, we manually inoke these
-    # calls before running Bazel to make sure they end up in Xcode's cache for
-    # quicker runs later.  All of these calls are obtained from xcrun calls in
-    # https://github.com/bazelbuild/bazel/blob/e8a69f5d5acaeb6af760631490ecbf73e8a04eeb/tools/cpp/osx_cc_configure.bzl.
-    # See https://github.com/bazelbuild/bazel/issues/17437 for more details.
-    # TODO(b/269503614) Remove this once Bazel provides an official solution.
-    - name: Warm up Xcode
-      if: ${{ runner.os == 'macOS' }}
-      shell: bash
-      run: |
-        mkdir -p mac_bazel_workaround
-        bazelisk ${{ steps.bazel.outputs.bazel-startup-flags }} build @bazel_tools//tools/osx:xcode_locator.m $BAZEL_FLAGS
-        XCODE_LOCATOR_FLAGS="--sdk macosx clang -mmacosx-version-min=10.9 -fobjc-arc -framework CoreServices -framework Foundation"
-        SINGLE_ARCH_COMPILE_FLAGS="--sdk macosx clang -mmacosx-version-min=10.9 -std=c++11 -lc++ -O3"
-        COMPILE_FLAGS="$SINGLE_ARCH_COMPILE_FLAGS -arch arm64 -arch x86_64 -Wl,-no_adhoc_codesign -Wl,-no_uuid -O3"
-        time env -i DEVELOPER_DIR=$DEVELOPER_DIR xcrun $XCODE_LOCATOR_FLAGS -o mac_bazel_workaround/xcode-locator-bin $(bazel info output_base)/external/bazel_tools/tools/osx/xcode_locator.m
-        time env -i DEVELOPER_DIR=$DEVELOPER_DIR xcrun $SINGLE_ARCH_COMPILE_FLAGS -o mac_bazel_workaround/libtool_check_unique $(bazel info output_base)/external/bazel_tools/tools/objc/libtool_check_unique.cc
-        time env -i DEVELOPER_DIR=$DEVELOPER_DIR xcrun $COMPILE_FLAGS -o mac_bazel_workaround/libtool_check_unique $(bazel info output_base)/external/bazel_tools/tools/objc/libtool_check_unique.cc
-        time env -i DEVELOPER_DIR=$DEVELOPER_DIR xcrun $SINGLE_ARCH_COMPILE_FLAGS -o mac_bazel_workaround/wrapped_clang $(bazel info output_base)/external/bazel_tools/tools/osx/crosstool/wrapped_clang.cc
-        time env -i DEVELOPER_DIR=$DEVELOPER_DIR xcrun $COMPILE_FLAGS -o mac_bazel_workaround/wrapped_clang $(bazel info output_base)/external/bazel_tools/tools/osx/crosstool/wrapped_clang.cc
-
     - name: Run Bash
       if: ${{ inputs.bash }}
       run: ${{ inputs.bash }}


### PR DESCRIPTION
This fixes the issue discovered in https://github.com/bazelbuild/bazel/issues/17437.  We should default to Bazel 6 on all Mac builds, where we can set the BAZEL_OSX_EXECUTE_TIMEOUT override.  Setting it to 5 minutes (the internal maximum) prevents any observable flake rate from this issue

Tested via: https://github.com/protocolbuffers/protobuf/actions/runs/5382614222