### PR TITLE
Add support for exclude-targets flag in Bazel workflows

### DIFF
--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -38,6 +38,10 @@ inputs:
     required: false
     description: "A bash command to run.  $BAZEL_FLAGS will be available to use for bazel runs."
     type: string
+  exclude-targets:
+    required: false
+    description: "Bazel target patterns to exclude. Each pattern must be prefixed with a minus sign."
+    type: string
 
 runs:
   using: 'composite'
@@ -87,7 +91,7 @@ runs:
       if: ${{ !inputs.bash }}
       with:
         image: ${{ inputs.image }}
-        command: ${{ inputs.bazel }} ${{ env.BAZEL_FLAGS }}
+        command: ${{ inputs.bazel }} ${{ env.BAZEL_FLAGS }} -- ${{ inputs.exclude-targets }}
 
     - name: Save Bazel repository cache
       # Only allow repository cache updates during post-submits.

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -41,6 +41,10 @@ inputs:
       A bash command to run.  $BAZEL_FLAGS and $BAZEL_STARTUP_FLAGS will be
       available to use for bazel runs.
     type: string
+  exclude-targets:
+    required: false
+    description: "Bazel target patterns to exclude. Each pattern must be prefixed with a minus sign."
+    type: string
 
 runs:
   using: 'composite'
@@ -132,7 +136,7 @@ runs:
       if: ${{ !inputs.bash }}
       run: >-
         bazelisk ${{ steps.bazel.outputs.bazel-startup-flags }}
-        ${{ inputs.bazel }} $BAZEL_FLAGS
+        ${{ inputs.bazel }} $BAZEL_FLAGS -- ${{ inputs.exclude-targets }}
       shell: bash
 
     - name: Save Bazel repository cache


### PR DESCRIPTION
This provides a way for test runs to exclude target patterns like this:

```
exclude-targets: -//foo/... -//bar:baz
```

We need special support for this because Bazel requires these arguments to appear after `--`. Our workflows add their own flags on the end of the `bazel` command, so we need a separate mechanism to make sure we put these exclusion patterns at the end of the command line.

An alternative possibility would be to call this flag `targets` instead of `exclude-targets`, and encourage test runs to specify both positive and negative target patterns here. However, we decided against this because we want to make it extra difficult to disable tests by mistake.