### PR TITLE
Update Bazel actions to add `--` only when `exclude-targets` is used

### DIFF
--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -91,7 +91,7 @@ runs:
       if: ${{ !inputs.bash }}
       with:
         image: ${{ inputs.image }}
-        command: ${{ inputs.bazel }} ${{ env.BAZEL_FLAGS }} -- ${{ inputs.exclude-targets }}
+        command: ${{ inputs.bazel }} ${{ env.BAZEL_FLAGS }} ${{ inputs.exclude-targets && format('-- {0}', inputs.exclude-targets) || '' }}
 
     - name: Save Bazel repository cache
       # Only allow repository cache updates during post-submits.

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -136,7 +136,7 @@ runs:
       if: ${{ !inputs.bash }}
       run: >-
         bazelisk ${{ steps.bazel.outputs.bazel-startup-flags }}
-        ${{ inputs.bazel }} $BAZEL_FLAGS -- ${{ inputs.exclude-targets }}
+        ${{ inputs.bazel }} $BAZEL_FLAGS ${{ inputs.exclude-targets && format('-- {0}', inputs.exclude-targets) || '' }}
       shell: bash
 
     - name: Save Bazel repository cache


### PR DESCRIPTION
This will help us avoid breaking some older Docker images that expect to add additional flags on the end of the command line.