### PR TITLE
Tweak actions to enable auto-generation of CMake files

### DIFF
--- a/internal/bazel-setup/action.yml
+++ b/internal/bazel-setup/action.yml
@@ -57,7 +57,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        echo "BAZEL_FLAGS=$BAZEL_FLAGS --xcode_version_config=//.github:host_xcodes" >> $GITHUB_ENV
+        echo "BAZEL_FLAGS=$BAZEL_FLAGS --xcode_version_config=@com_google_protobuf//.github:host_xcodes" >> $GITHUB_ENV
         echo "DEVELOPER_DIR=${{ env.DEVELOPER_DIR || '/Applications/Xcode_14.1.app/Contents/Developer' }}" >> $GITHUB_ENV
 
     - name: Configure Bazel caching

--- a/internal/gcloud-auth/action.yml
+++ b/internal/gcloud-auth/action.yml
@@ -43,13 +43,6 @@ runs:
       shell: bash
       run: echo "CREDENTIALS_FILE=${{ steps.auth.outputs.credentials_file_path }}" >> $GITHUB_ENV
 
-    - name: Fix credentials path (Windows)
-      if: ${{ runner.os == 'Windows' }}
-      # Bash commands in windows don't like the backslash in the file path.
-      # Assume we're running in the root directory and grab the base name.
-      shell: bash
-      run: echo "CREDENTIALS_FILE="$(basename ${CREDENTIALS_FILE//\\//}) >> $GITHUB_ENV
-
     - name: Output credentials file
       id: output
       shell: bash


### PR DESCRIPTION
To run upb's staleness tests, we need to cd into the upb/ directory and invoke Bazel from the workspace there. For that to work, I found that we needed two tweaks:
- Canonicalize a reference to `//.github` so that it's always interpreted as part of `com_google_protobuf` and not upb.
- Fix a Windows file path to be absolute instead of relative. I had to remove a workaround to do this, but that seemed to work correctly without breaking anything as far as I can tell.