### PR TITLE
Reduce flakes from QEMU setup

### DIFF
--- a/internal/docker-run/action.yml
+++ b/internal/docker-run/action.yml
@@ -41,6 +41,8 @@ runs:
       run: gcloud auth configure-docker -q us-docker.pkg.dev
 
     - name: Setup QEMU for possible emulation
+      # Most tests don't require this, so just continue if there's a network issue.
+      continue-on-error: true
       uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
       with:
         # This is mirrored for better reliability.

--- a/internal/docker-run/action.yml
+++ b/internal/docker-run/action.yml
@@ -40,8 +40,8 @@ runs:
       shell: bash
       run: gcloud auth configure-docker -q us-docker.pkg.dev
 
-    - name: Setup QEMU for possible emulation
-      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+#    - name: Setup QEMU for possible emulation
+#      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
 
     - name: Check docker cache
       if: ${{ inputs.docker-cache }}

--- a/internal/docker-run/action.yml
+++ b/internal/docker-run/action.yml
@@ -40,8 +40,11 @@ runs:
       shell: bash
       run: gcloud auth configure-docker -q us-docker.pkg.dev
 
-#    - name: Setup QEMU for possible emulation
-#      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+    - name: Setup QEMU for possible emulation
+      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+      with:
+        # This is mirrored for better reliability.
+        image: us-docker.pkg.dev/protobuf-build/containers/test/binfmt@sha256:cf38696ffb9927c3433ad496a715b12ca94e67e67e9729ddf5dedbdb37e53b4d
 
     - name: Check docker cache
       if: ${{ inputs.docker-cache }}


### PR DESCRIPTION
We've mirrored this image to GAR to avoid flakes from docker hub connections.  This also uses `continue-on-error` to ignore failed pulls.  Most tests don't even need this step, and the ones that do will fail very obviously later on