### PR TITLE
Fix ccache on windows

### DIFF
--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -58,7 +58,7 @@ runs:
         echo "CCACHE_MAXSIZE=150M" >> $GITHUB_ENV
         echo "CCACHE_SLOPPINESS=clang_index_store,include_file_ctime,include_file_mtime,file_macro,time_macros" >> $GITHUB_ENV
         echo "CCACHE_DIRECT=true" >> $GITHUB_ENV
-        echo "CCACHE_CMAKE_FLAGS=-Dprotobuf_ALLOW_CCACHE=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache || echo "ccache")" >> $GITHUB_ENV
+        echo "CCACHE_CMAKE_FLAGS=-Dprotobuf_ALLOW_CCACHE=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
 
     - name: Setup ccache on Windows
       if: ${{ runner.os == 'Windows' }}

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -75,7 +75,7 @@ runs:
     - name: Check ccache version
       shell: bash
       run: |
-        which ccache
+        which ccache || echo "No local ccache installation found"
         ccache --version || echo "No local ccache installation found"
 
     - name: Setup fixed path ccache caching

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -58,7 +58,7 @@ runs:
         echo "CCACHE_MAXSIZE=150M" >> $GITHUB_ENV
         echo "CCACHE_SLOPPINESS=clang_index_store,include_file_ctime,include_file_mtime,file_macro,time_macros" >> $GITHUB_ENV
         echo "CCACHE_DIRECT=true" >> $GITHUB_ENV
-        echo "CCACHE_CMAKE_FLAGS=-Dprotobuf_ALLOW_CCACHE=ON -DCMAKE_C_COMPILER_LAUNCHER=$(which ccache || echo "ccache") -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache || echo "ccache")" >> $GITHUB_ENV
+        echo "CCACHE_CMAKE_FLAGS=-Dprotobuf_ALLOW_CCACHE=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache || echo "ccache")" >> $GITHUB_ENV
 
     - name: Setup ccache on Windows
       if: ${{ runner.os == 'Windows' }}

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -72,6 +72,10 @@ runs:
       shell: bash
       run: brew install ccache
 
+    - name: Check ccache version
+      shell: bash
+      run: ccache --version || echo "No local ccache installation found"
+
     - name: Setup fixed path ccache caching
       uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # v3.2.4
       with:

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -58,7 +58,6 @@ runs:
         echo "CCACHE_MAXSIZE=150M" >> $GITHUB_ENV
         echo "CCACHE_SLOPPINESS=clang_index_store,include_file_ctime,include_file_mtime,file_macro,time_macros" >> $GITHUB_ENV
         echo "CCACHE_DIRECT=true" >> $GITHUB_ENV
-        echo "CCACHE_CMAKE_FLAGS=-Dprotobuf_ALLOW_CCACHE=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
 
     - name: Setup ccache on Windows
       if: ${{ runner.os == 'Windows' }}
@@ -72,9 +71,10 @@ runs:
       shell: bash
       run: brew install ccache
 
-    - name: Check ccache version
+    - name: Configure ccache cmake arguments
       shell: bash
       run: |
+        echo "CCACHE_CMAKE_FLAGS=-Dprotobuf_ALLOW_CCACHE=ON -DCMAKE_C_COMPILER_LAUNCHER=$(which ccache || echo 'ccache') -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache || echo 'ccache')" >> $GITHUB_ENV
         which ccache || echo "No local ccache installation found"
         ccache --version || echo "No local ccache installation found"
 

--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -74,7 +74,9 @@ runs:
 
     - name: Check ccache version
       shell: bash
-      run: ccache --version || echo "No local ccache installation found"
+      run: |
+        which ccache
+        ccache --version || echo "No local ccache installation found"
 
     - name: Setup fixed path ccache caching
       uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # v3.2.4


### PR DESCRIPTION
Our windows 2022 runners have an old version of ccache by default that was taking precedence.  This old version isn't actually compatible with msvc 2022, blowing up our build times.

This was verified to work in a temporary PR in the protobuf repo (https://github.com/protocolbuffers/protobuf/pull/13920)