### PR TITLE
Fix a bug in jobs w/o sccache setup

### DIFF
--- a/internal/docker-run/action.yml
+++ b/internal/docker-run/action.yml
@@ -83,18 +83,19 @@ runs:
 
     - name: Forward sccache arguments
       shell: bash
+      id: sccache
       if: ${{ env.SCCACHE_GCS_KEY_PATH != '' }}
       run: >
-        echo "SCCACHE_DOCKER_ARGS=(
+        echo "args="
         -e SCCACHE_GCS_RW_MODE=$SCCACHE_GCS_RW_MODE
         -e SCCACHE_GCS_BUCKET=$SCCACHE_GCS_BUCKET
         -e SCCACHE_GCS_KEY_PREFIX=$SCCACHE_GCS_KEY_PREFIX
-        -e SCCACHE_GCS_KEY_PATH=/workspace/$(basename $SCCACHE_GCS_KEY_PATH) )
-        " >> $GITHUB_ENV
+        -e SCCACHE_GCS_KEY_PATH=/workspace/$(basename $SCCACHE_GCS_KEY_PATH)
+        "" >> $GITHUB_OUTPUT
 
     - name: Run docker
       shell: bash
       run: >
-        time docker run "${SCCACHE_DOCKER_ARGS[@]}"
+        time docker run ${{ steps.sccache.outputs.args }}
         ${{ inputs.run-flags}} -v${{ github.workspace }}:/workspace
         ${{ inputs.image }} ${{ inputs.command }}

--- a/internal/docker-run/action.yml
+++ b/internal/docker-run/action.yml
@@ -85,16 +85,16 @@ runs:
       shell: bash
       if: ${{ env.SCCACHE_GCS_KEY_PATH != '' }}
       run: >
-        echo "SCCACHE_DOCKER_ARGS=\"
+        echo "SCCACHE_DOCKER_ARGS=(
         -e SCCACHE_GCS_RW_MODE=$SCCACHE_GCS_RW_MODE
         -e SCCACHE_GCS_BUCKET=$SCCACHE_GCS_BUCKET
         -e SCCACHE_GCS_KEY_PREFIX=$SCCACHE_GCS_KEY_PREFIX
-        -e SCCACHE_GCS_KEY_PATH=/workspace/$(basename $SCCACHE_GCS_KEY_PATH)\"
+        -e SCCACHE_GCS_KEY_PATH=/workspace/$(basename $SCCACHE_GCS_KEY_PATH) )
         " >> $GITHUB_ENV
 
     - name: Run docker
       shell: bash
       run: >
-        time docker run ${{ inputs.run-flags}} -v${{ github.workspace }}:/workspace
-        $SCCACHE_DOCKER_ARGS
+        time docker run "${SCCACHE_DOCKER_ARGS[@]}"
+        ${{ inputs.run-flags}} -v${{ github.workspace }}:/workspace
         ${{ inputs.image }} ${{ inputs.command }}

--- a/internal/docker-run/action.yml
+++ b/internal/docker-run/action.yml
@@ -81,12 +81,20 @@ runs:
       if: ${{ !inputs.docker-cache }}
       run: time docker pull -q ${{ inputs.image }}
 
+    - name: Forward sccache arguments
+      shell: bash
+      if: ${{ env.SCCACHE_GCS_KEY_PATH != '' }}
+      run: >
+        echo "SCCACHE_DOCKER_ARGS=\"
+        -e SCCACHE_GCS_RW_MODE=$SCCACHE_GCS_RW_MODE
+        -e SCCACHE_GCS_BUCKET=$SCCACHE_GCS_BUCKET
+        -e SCCACHE_GCS_KEY_PREFIX=$SCCACHE_GCS_KEY_PREFIX
+        -e SCCACHE_GCS_KEY_PATH=/workspace/$(basename $SCCACHE_GCS_KEY_PATH)\"
+        " >> $GITHUB_ENV
+
     - name: Run docker
       shell: bash
       run: >
         time docker run ${{ inputs.run-flags}} -v${{ github.workspace }}:/workspace
-        -e SCCACHE_GCS_RW_MODE=$SCCACHE_GCS_RW_MODE
-        -e SCCACHE_GCS_BUCKET=$SCCACHE_GCS_BUCKET
-        -e SCCACHE_GCS_KEY_PREFIX=$SCCACHE_GCS_KEY_PREFIX
-        -e SCCACHE_GCS_KEY_PATH=/workspace/$(basename $SCCACHE_GCS_KEY_PATH || echo "unknown")
+        $SCCACHE_DOCKER_ARGS
         ${{ inputs.image }} ${{ inputs.command }}


### PR DESCRIPTION
By forwarding bad environment variables, we actually break the `sccache -z` and `sccache -s` commands embedded in our docker images