### PR TITLE
Fix retry behavior on failed submodule init

### DIFF
--- a/checkout/action.yml
+++ b/checkout/action.yml
@@ -39,4 +39,6 @@ runs:
         max_attempts: 5
         shell: bash
         command: |
+          git submodule deinit --all -f
+          git submodule sync
           git submodule update --force --init ${{ inputs.submodules == 'recursive' && '--recursive' || '' }}


### PR DESCRIPTION
We're still seeing flakes from submodule initialization because the failed attempt leaves git in a bad state