### PR TITLE
Remove platform-specific flags from protobuf-ci

### DIFF
--- a/internal/bazel-setup/action.yml
+++ b/internal/bazel-setup/action.yml
@@ -39,25 +39,10 @@ runs:
       shell: bash
       run: echo "BAZEL=bazelisk" >> $GITHUB_ENV
 
-    - name: Initialize Windows startup flags
-      if: runner.os == 'Windows'
-      shell: bash
-      run: echo "BAZEL_STARTUP_FLAGS=--output_user_root=C:/tmp --windows_enable_symlinks" >> $GITHUB_ENV
-
     - name: Initialize Bazel flags
       shell: bash
       run: echo "BAZEL_FLAGS=--keep_going --test_output=errors --test_timeout=600" >> $GITHUB_ENV
 
-    - name: Initialize Windows-specific Bazel flags
-      if: runner.os == 'Windows'
-      shell: bash
-      run: echo "BAZEL_FLAGS=$BAZEL_FLAGS --enable_runfiles" >> $GITHUB_ENV
-
-    - name: Initialize MacOS-specific Bazel flags
-      if: runner.os == 'macOS'
-      shell: bash
-      run: |
-        echo "BAZEL_FLAGS=$BAZEL_FLAGS --xcode_version_config=@com_google_protobuf//.github:host_xcodes" >> $GITHUB_ENV
 
     - name: Configure Bazel caching
       # Skip bazel cache for local act runs due to issue with credential files


### PR DESCRIPTION
These can be specified in platform-specific bazelrc files, allowing us more freedom to adjust them.  This will be a breaking change and require a major version bump