### PR TITLE
Use a hash of the image url in the bazel cache key

### DIFF
--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -62,12 +62,16 @@ runs:
     - name: Setup Runner
       uses: ./../../_actions/current/internal/setup-runner
 
+    - name: Calculate Image Hash
+      id: image-hash
+      run: echo ::set-output name=value::$(echo ${{ inputs.image }} | md5sum | cut -f1 -d" ")
+
     - name: Setup Bazel
       id: bazel
       uses: ./../../_actions/current/internal/bazel-setup
       with:
         credentials-file: /workspace/$(basename ${{ steps.auth.outputs.credentials-file }})
-        bazel-cache: ${{ inputs.bazel-cache }}
+        bazel-cache: ${{ inputs.bazel-cache }}-${{ steps.image-hash.outputs.value }}
 
     - name: Hook up repository Cache
       shell: bash

--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -64,6 +64,7 @@ runs:
 
     - name: Calculate Image Hash
       id: image-hash
+      shell: bash
       run: echo ::set-output name=value::$(echo ${{ inputs.image }} | md5sum | cut -f1 -d" ")
 
     - name: Setup Bazel


### PR DESCRIPTION
This will avoid real issues with new images being masked by reused build artifacts