### PR TITLE
Add Debugging and Error Handling to GHA Bash Actions

### DIFF
--- a/bash/action.yml
+++ b/bash/action.yml
@@ -51,4 +51,6 @@ runs:
 
     - name: Run
       shell: bash
-      run: ${{ inputs.command }}
+      run: |
+        set -ex
+        ${{ inputs.command }}

--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -89,7 +89,7 @@ runs:
       with:
         image: ${{ inputs.image }}
         run-flags: --entrypoint "/bin/bash"
-        command: -l -c "${{ inputs.bash }}"
+        command: -l -c "set -ex; ${{ inputs.bash }}"
 
     - name: Run Bazel Docker
       uses: ./../../_actions/current/internal/docker-run

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -129,7 +129,9 @@ runs:
 
     - name: Run Bash
       if: ${{ inputs.bash }}
-      run: ${{ inputs.bash }}
+      run: |
+        set -ex
+        ${{ inputs.bash }}
       shell: bash
 
     - name: Run Bazel


### PR DESCRIPTION
Add `set -ex` to all actions that run a user-supplied bash command to ensure we properly surface errors and provide more debug logs.