### PR TITLE
Clear GHA warnings from bad patterns in protobuf-ci

### DIFF
--- a/bazel-docker/action.yml
+++ b/bazel-docker/action.yml
@@ -65,7 +65,7 @@ runs:
     - name: Calculate Image Hash
       id: image-hash
       shell: bash
-      run: echo ::set-output name=value::$(echo ${{ inputs.image }} | md5sum | cut -f1 -d" ")
+      run: echo "value=$(echo ${{ inputs.image }} | md5sum | cut -f1 -d' ')" >> $GITHUB_OUTPUT
 
     - name: Setup Bazel
       id: bazel

--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -98,14 +98,14 @@ runs:
 
     - name: Cache Bazelisk
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
-      uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # v3.2.4
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ${{ env.BAZELISK_PATH }}
         key: bazel-${{ runner.os }}-${{ inputs.version }}
 
     - name: Restore Bazelisk
       if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
-      uses: actions/cache/restore@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # v3.2.4
+      uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ${{ env.BAZELISK_PATH }}
         key: bazel-${{ runner.os }}-${{ inputs.version}}

--- a/composer-setup/action.yml
+++ b/composer-setup/action.yml
@@ -29,7 +29,7 @@ runs:
     # This is the trusted path, which can upload to our cache.
     - name: Cache Composer dependencies
       if: ${{ github.event_name != 'pull_request_target' }}
-      uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # v3.2.4
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ${{ github.workspace }}/composer-cache
         key: composer-${{ runner.os }}-${{ inputs.cache-prefix }}-${{ hashFiles(format('{0}/composer.json', inputs.directory)) }}
@@ -40,7 +40,7 @@ runs:
     # Identical to the above, but will never upload a new cache (untrusted path).
     - name: Restore Composer dependencies from cache
       if: ${{ github.event_name == 'pull_request_target' }}
-      uses: actions/cache/restore@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # v3.2.4
+      uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ${{ github.workspace }}/composer-cache
         key: composer-${{ runner.os }}-${{ inputs.cache-prefix }}-${{ hashFiles(format('{0}/composer.json', inputs.directory)) }}

--- a/internal/ccache-setup-windows/action.yml
+++ b/internal/ccache-setup-windows/action.yml
@@ -50,7 +50,7 @@ runs:
     - name: Setup caching of ccache download
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
       id: ccache-cache
-      uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # v3.2.4
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ${{ env.CCACHE_EXE_PATH }}
         key: ccache-exe-${{ inputs.ccache-version }}
@@ -58,7 +58,7 @@ runs:
     - name: Restore ccache download
       if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
       id: ccache-restore
-      uses: actions/cache/restore@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # v3.2.4
+      uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ${{ env.CCACHE_EXE_PATH }}
         key: ccache-exe-${{ inputs.ccache-version }}

--- a/internal/docker-run/action.yml
+++ b/internal/docker-run/action.yml
@@ -58,7 +58,7 @@ runs:
     - name: Check docker cache
       if: ${{ inputs.docker-cache }}
       id: check-docker-cache
-      uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # v3.2.4
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ci/docker/
         key: ${{ inputs.image }}

--- a/internal/gcloud-auth/action.yml
+++ b/internal/gcloud-auth/action.yml
@@ -31,10 +31,12 @@ runs:
     - name: Authenticate to Google Cloud
       id: auth
       uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
+      if: ${{ env.CREDENTIALS_FILE == '' }}
       with:
         credentials_json: ${{ inputs.credentials }}
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
+      if: ${{ env.CREDENTIALS_FILE == '' }}
       with:
         version: ">= 446.0.0"
     - name: Use gcloud CLI
@@ -42,6 +44,7 @@ runs:
       run: gcloud info
 
     - name: Store credentials path
+      if: ${{ env.CREDENTIALS_FILE == '' }}
       shell: bash
       run: echo "CREDENTIALS_FILE=${{ steps.auth.outputs.credentials_file_path }}" >> $GITHUB_ENV
 

--- a/internal/repository-cache-restore/action.yml
+++ b/internal/repository-cache-restore/action.yml
@@ -45,7 +45,7 @@ runs:
       id: restore-cache
       # Skip if there's already a downloaded cache
       if: ${{ hashFiles(format('{0}/{1}', github.workspace, env.REPOSITORY_CACHE_PATH)) == '' }}
-      uses: actions/cache/restore@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # v3.2.4
+      uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ${{ github.workspace }}/${{ env.REPOSITORY_CACHE_PATH }}
         key: ${{ env.REPOSITORY_CACHE_NAME }}

--- a/internal/repository-cache-save/action.yml
+++ b/internal/repository-cache-save/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
     - name: Save modified Bazel repository cache
       if: ${{ env.REPOSITORY_CACHE_HASH != hashFiles(format('{0}/**', env.REPOSITORY_CACHE_PATH)) }}
-      uses: actions/cache/save@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # v3.2.4
+      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ${{ github.workspace }}/${{ env.REPOSITORY_CACHE_PATH }}
         key: ${{ env.REPOSITORY_CACHE_BASE }}-${{ github.sha }}


### PR DESCRIPTION
- Update some deprecated action dependencies
- Stop using deprecated `set-output` feature
- Avoid authenticating with gcloud multiple times

None of these should be breaking changes (tested in https://github.com/protocolbuffers/protobuf/pull/20093)