### PR TITLE
Pin GitHub Actions to immutable SHA hashes

### DIFF
--- a/checkout/action.yml
+++ b/checkout/action.yml
@@ -26,13 +26,13 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout pending changes
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         ref: ${{ inputs.ref }}
 
     - name: Checkout submodules
       if: ${{ inputs.submodules }}
-      uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
       with:
         timeout_seconds: 30
         retry_wait_seconds: 30

--- a/internal/docker-run/action.yml
+++ b/internal/docker-run/action.yml
@@ -38,7 +38,7 @@ runs:
   steps:
     - name: Validate Docker image
       if: ${{ github.event_name == 'pull_request_target' && contains(inputs.image, 'us-docker.pkg.dev/protobuf-build/release-containers/') }}
-      uses: actions/github-script@v3
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       with:
         script: |
           core.setFailed('Pull requests from forks cannot use release Docker images.')
@@ -50,7 +50,7 @@ runs:
     - name: Setup QEMU for possible emulation
       # Most tests don't require this, so just continue if there's a network issue.
       continue-on-error: true
-      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+      uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25  # v3.4.0
       with:
         # This is mirrored for better reliability.
         image: us-docker.pkg.dev/protobuf-build/containers/test/binfmt@sha256:cf38696ffb9927c3433ad496a715b12ca94e67e67e9729ddf5dedbdb37e53b4d
@@ -58,7 +58,7 @@ runs:
     - name: Check docker cache
       if: ${{ inputs.docker-cache }}
       id: check-docker-cache
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f  # v4.2.1
       with:
         path: ci/docker/
         key: ${{ inputs.image }}
@@ -79,7 +79,7 @@ runs:
     - name: Pull fresh docker image
       if: ${{ !inputs.docker-cache }}
       id: docker-pull
-      uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
       with:
         timeout_minutes: 5
         retry_wait_seconds: 60

--- a/internal/gcloud-auth/action.yml
+++ b/internal/gcloud-auth/action.yml
@@ -30,12 +30,12 @@ runs:
   steps:
     - name: Authenticate to Google Cloud
       id: auth
-      uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
+      uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935  # v2.1.8
       if: ${{ env.CREDENTIALS_FILE == '' }}
       with:
         credentials_json: ${{ inputs.credentials }}
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
+      uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a  # v2.1.4
       if: ${{ env.CREDENTIALS_FILE == '' }}
       with:
         version: ">= 446.0.0"


### PR DESCRIPTION
## Summary
This PR updates GitHub Actions to their latest versions and pins them to specific SHA hashes rather than version tags to mitigate supply chain attack risks.

## Security Rationale
Using version tags like `@v3` creates a security vulnerability as the content behind those tags can be modified at any time by action maintainers or by attackers who compromise their accounts. Recent supply chain attacks like the xz vulnerability (CVE-2024-3094) demonstrate how dependencies can be compromised through trusted distribution mechanisms.

By pinning to immutable SHA hashes, we ensure that the exact code run by our workflows is never silently changed.

## Changes
This PR updates the following GitHub Actions:

| Action | From | To |
|--------|------|-----|
| actions/github-script | v3 | v7.0.1 (60a0d83039c74a4aee543508d2ffcb1c3799cdea) |
| docker/setup-qemu-action | e81a89b1732b9c48d79cd809d8d81d79c4647a18 | v3.4.0 (4574d27a4764455b42196d70a065bc6853246a25) |
| actions/cache | 1bd1e32a3bdc45362d1e726936510720a7c30a57 | v4.2.1 (0c907a75c2c80ebcb7f088228285e798b750cf8f) |
| nick-fields/retry | 943e742917ac94714d2f408a0e8320f2d1fcafcd | v3.0.2 (ce71cc2ab81d554ebbe88c79ab5975992d79ba08) |
| google-github-actions/auth | ef5d53e30bbcd8d0836f4288f5e50ff3e086997d | v2.1.8 (71f986410dfbc7added4569d411d040a91dc6935) |
| google-github-actions/setup-gcloud | e30db14379863a8c79331b04a9969f4c1e225e0b | v2.1.4 (77e7a554d41e2ee56fc945c52dfd3f33d12def9a) |

## Notable Security Improvements
- Fixed `actions/github-script@v3` which is used in Docker image validation - a critical security control
- All actions are now pinned to specific SHA hashes with version tags commented for reference
- Updates include security patches and performance improvements from newer versions

## Testing
All workflows have been manually validated to ensure they continue to function with the updated action versions.