### PR TITLE
Updated default Bazel version to 7.5.0.

### DIFF
--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -29,7 +29,7 @@ inputs:
   version:
     required: false
     description: A pinned Bazel version to use
-    default: '6.4.0'
+    default: '7.5.0'
     type: string
   bazel:
     required: false


### PR DESCRIPTION
Some of our jobs appear to be using this default, and we want all of our jobs off of Bazel 6.