### PR TITLE
Upgrade the LLVM version in Windows Bazel test runs

### DIFF
--- a/bazel/action.yml
+++ b/bazel/action.yml
@@ -96,6 +96,13 @@ runs:
       shell: bash
       run: echo "BAZELISK_PATH=$LOCALAPPDATA\bazelisk" >> $GITHUB_ENV
 
+    # Sometimes the Clang version on the Windows runner is too old to function
+    # correctly, so we need to upgrade it.
+    - name: Upgrade LLVM
+      if: runner.os == 'Windows'
+      shell: bash
+      run: choco upgrade llvm
+
     - name: Cache Bazelisk
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0


### PR DESCRIPTION
This should fix some errors we are seeing about the Clang version being too old. This fix was suggested
[here](https://github.com/actions/runner-images/issues/10001).