### PR TITLE
Make windows line break hack fail quietly

### DIFF
--- a/internal/setup-runner/action.yml
+++ b/internal/setup-runner/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Fix Windows line breaks
       if: runner.os == 'Windows'
       shell: bash
-      run: find . -type f -print0 | xargs -0 d2u
+      run: find . -type f -print0 | xargs -0 d2u || echo "Ignoring failure"
 
     - name: Install bazelrc files
       shell: bash

--- a/internal/setup-runner/action.yml
+++ b/internal/setup-runner/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Fix Windows line breaks
       if: runner.os == 'Windows'
       shell: bash
-      run: find . -type f -print0 | xargs -0 d2u || echo "Ignoring failure"
+      run: find . -type f -print0 | xargs -0 d2u 2>/dev/null || echo "Ignoring failure"
 
     - name: Install bazelrc files
       shell: bash

--- a/internal/setup-runner/action.yml
+++ b/internal/setup-runner/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Fix Windows line breaks
       if: runner.os == 'Windows'
       shell: bash
-      run: find . -type f -print0 | xargs -0 d2u 2>/dev/null
+      run: find . -type f -print0 | xargs -0 d2u
 
     - name: Install bazelrc files
       shell: bash


### PR DESCRIPTION
This seems to start failing on the newest windows images, but only *after* it's finished converting all our files anyway.  This entire hack only needs to be best-effort, we should continue on failure