### PR TITLE
Make windows line break hack fail quietly (#57)

### DIFF
--- a/internal/setup-runner/action.yml
+++ b/internal/setup-runner/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Fix Windows line breaks
       if: runner.os == 'Windows'
       shell: bash
-      run: find . -type f -print0 | xargs -0 d2u 2>/dev/null
+      run: find . -type f -print0 | xargs -0 d2u 2>/dev/null || echo "Ignoring failure"
 
     - name: Install bazelrc files
       shell: bash


### PR DESCRIPTION
* Remove error suppression from line break fix

* ignore errors

* silence error logs