### PR TITLE
remove reference to bazel-version

### DIFF
--- a/bash/action.yml
+++ b/bash/action.yml
@@ -47,7 +47,6 @@ runs:
         bazel-cache: regenerate-stale-files
         bash: ./regenerate_stale_files.sh $BAZEL_FLAGS
         bazel-flags: ${{ inputs.bazel-flags }}
-        version: ${{ inputs.bazel-version }}
 
     - name: Run
       shell: bash


### PR DESCRIPTION
bazel-version has not yet been introduced. Remove to fall back on default version.