### PR TITLE
Use restore-only ccache on pull_request_target

### DIFF
--- a/ccache/action.yml
+++ b/ccache/action.yml
@@ -79,6 +79,7 @@ runs:
         ccache --version || echo "No local ccache installation found"
 
     - name: Setup fixed path ccache caching
+      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: |
@@ -91,6 +92,20 @@ runs:
         # 1) The exact same commit we're running over
         # 2) The latest cache from the current ref branch
         # 3) The latest push to the base ref of a pull request
+        restore-keys: |
+          ${{ format('ccache-{0}-{1}-{2}', inputs.cache-prefix, github.ref_name, github.sha) }}
+          ${{ format('ccache-{0}-{1}', inputs.cache-prefix, github.ref_name) }}
+          ${{ format('ccache-{0}-{1}', inputs.cache-prefix, github.base_ref) }}
+
+    - name: Restore fixed path ccache
+      if: ${{ github.event_name == 'pull_request_target' }}
+      uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      with:
+        path: |
+          .ccache/**
+          !.ccache/lock
+          !.ccache/tmp
+        key: ${{ format('ccache-{0}-{1}-{2}', inputs.cache-prefix, github.ref_name, github.sha) }}
         restore-keys: |
           ${{ format('ccache-{0}-{1}-{2}', inputs.cache-prefix, github.ref_name, github.sha) }}
           ${{ format('ccache-{0}-{1}', inputs.cache-prefix, github.ref_name) }}


### PR DESCRIPTION
This updates the ccache setup action to use `actions/cache/restore` for `pull_request_target` runs.

`pull_request_target` jobs can run code from a fork after maintainer approval. In that context, the job should be able to restore existing ccache state, but it should not save new `.ccache` contents back into a cache namespace later consumed by trusted branch runs.

This matches the restore-only pattern already used by `composer-setup` and `internal/ccache-setup-windows`.

Validation:
- Parsed `ccache/action.yml` as YAML.
- Confirmed the trusted cache step still uses `actions/cache` when `github.event_name != 'pull_request_target'`.
- Confirmed the `pull_request_target` path now uses `actions/cache/restore` with the same path, key, and restore keys.
